### PR TITLE
Change AB test type from full_mailing to subject

### DIFF
--- a/CRM/Mosaico/AbDemux.php
+++ b/CRM/Mosaico/AbDemux.php
@@ -162,7 +162,7 @@ class CRM_Mosaico_AbDemux {
       'mailing_id_a' => $a['id'],
       'mailing_id_b' => $b['id'],
       'mailing_id_c' => $c['id'],
-      'testing_criteria' => 'full_email',
+      'testing_criteria' => 'subject',
       'group_percentage' => CRM_Utils_Array::value('variantsPct', $a['template_options'], self::DEFAULT_AB_PERCENTAGE),
       'winner_criteria' => 'open',
       'declare_winning_time' => self::DEFAULT_WINNING_TIME,


### PR DESCRIPTION
Before: Manage A/B Mailings shows incorrect A/B test type
<img width="189" alt="image" src="https://user-images.githubusercontent.com/25517556/197679480-8aa945be-c3ef-4eb7-b6d9-0011efe8f182.png">

After: Correct A/B test type
<img width="191" alt="image" src="https://user-images.githubusercontent.com/25517556/197679636-96f7ede8-128d-43ea-a4c7-7cf2e4278e91.png">
